### PR TITLE
the texture stretch is fixed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS        = -Wall -Wextra -Iincludes -O3#- g -g3 -ggdb3 # -fsanitize=address
+CFLAGS        = -Wall -Wextra -Iincludes -O3#-g -g3 -ggdb3 # -fsanitize=address
 SRC           = $(wildcard *.c ./src/*.c) # update accordantly
 OBJ           = $(SRC:%.c=$(OBJDIR)/%.o)
 LIBFT_ARCHIVE = $(LIB_DIR)/libft.a

--- a/cub.c
+++ b/cub.c
@@ -22,20 +22,6 @@ void game_rander(t_game *game)
 bool is_frame_ready()
 {
 	static time_t last_frame_time;
-	static time_t one_frame_time = 1000 / FRAME_RATE;
-	time_t now;
-
-	now = curr_time_ms();
-	if (now - last_frame_time < one_frame_time)
-		return (true);
-	// printf("FPS: %lu\n", 1000 / (now - last_frame_time));
-	last_frame_time = now;
-	return (true);
-}
-
-int game_loop(t_game *game)
-{
-	static time_t last_frame_time;
 	static int frames;
 
 	if (curr_time_ms() - last_frame_time > 1000)
@@ -44,26 +30,52 @@ int game_loop(t_game *game)
 		last_frame_time = curr_time_ms();
 		frames = 0;
 	}
-	// if (!is_frame_ready())
-	// 	return (0);
+	// if (now - last_frame_time < one_frame_time)
+	// 	return (false);
+	frames++;
+	return (true);
+}
+
+int game_loop(t_game *game)
+{
+	if (!is_frame_ready())
+		return (0);
 	game_handle_keyboard_events(game);
 	game_rander(game);
-	frames++;
 	return (0);
 }
 
+/*
+ * prepare_wall_images: loads wall textures from files and stores them in the frames struct.
+ * @tmp:   temporary variable that stores the result of the texture loading function (mlx_xpm_file_to_image).
+ * @x:     variable that holds the width of the texture.
+ * @y:     variable that holds the height of the texture.
+ * return: this function does not return a value.
+ */
 void	prepare_wall_images(t_game *game)
 {
 	void	*tmp;
+	int	x;
+	int	y;
+	int	bpp;
+	int	endian;
+	int	line_len;
 
-	tmp = mlx_xpm_file_to_image(game->mlx,"t1.xpm",
-		&game->frames.Dimensions[0][0], &game->frames.Dimensions[0][1]);
-	game->frames.walltex_[0] = mlx_get_data_addr(tmp,&game->frames.image[0].bpp,
-		&game->frames.image[0].line_len,&game->frames.image[0].endian);
-	tmp = mlx_xpm_file_to_image(game->mlx,"t2.xpm",&game->frames.Dimensions[1][0],
-		&game->frames.Dimensions[1][1]);
-	game->frames.walltex_[1] = mlx_get_data_addr(tmp,&game->frames.image[1].bpp,
-		&game->frames.image[1].line_len,&game->frames.image[1].endian);
+	tmp = mlx_xpm_file_to_image(game->mlx, "t1.xpm", &x, &y);
+	game->frames.walltex_[0].addr = mlx_get_data_addr(tmp,&bpp, &line_len, &endian);
+	game->frames.walltex_[0].height = y;
+	game->frames.walltex_[0].width = x;
+	game->frames.walltex_[0].bpp = bpp;
+	game->frames.walltex_[0].line_len = line_len;
+	game->frames.walltex_[0].endian = endian;
+	tmp = mlx_xpm_file_to_image(game->mlx,"t2.xpm", &x, &y);
+	game->frames.walltex_[1].addr = mlx_get_data_addr(tmp, &bpp, &line_len, &endian);
+	game->frames.walltex_[1].height = y;
+	game->frames.walltex_[1].width = x;
+	game->frames.walltex_[1].bpp = bpp;
+	game->frames.walltex_[1].line_len = line_len;
+	game->frames.walltex_[1].endian = endian;
+
 }
 
 int	main()

--- a/includes/types.h
+++ b/includes/types.h
@@ -62,19 +62,6 @@ typedef struct s_data
 	int		height;
 }			t_data;
 
-typedef struct s_parse
-{
-	int		height;
-	int		width;
-	double	px;
-	double	py;
-	void	*win;
-	void	*mlx;
-	bool	is_moving;
-	double	dir_;
-	t_data	data;
-}			t_parse;
-
 typedef struct s_player
 {
 	t_vec2 dir;
@@ -92,11 +79,13 @@ typedef struct s_world {
 }
 t_world;
 
+/*
+ * @t_framse:	struct holding wall textures and their boundaries
+ * @image:	array of t_data, each storing image info (bpp, address, line length, endian)
+ */
 typedef struct s_frames
 {
-	t_data	image[2];
-	char	*walltex_[2];
-	int	Dimensions[2][2];
+	t_data	walltex_[2];
 }	t_frames;
 
 typedef struct s_game
@@ -167,6 +156,7 @@ typedef struct s_dda_alog
 	t_vec2 ray;
 	double ray_size;
 	double hit_dist;
+	double line_height;
 	t_wall_side side;
 } t_dda_ctx;
 

--- a/src/dda.c
+++ b/src/dda.c
@@ -149,13 +149,10 @@ void calculate_wall_boundaries(t_game *game, t_dda_ctx *dda, int x)
 	line_height = game->screen_height / dda->hit_dist * TILE_SIZE;
 	h = game->screen_height;
 	dda->line_start.y = (h - line_height) / 2;
-	if(dda->line_start.y < 0)
-		dda->line_start.y = 0;
 	dda->line_end.y = (line_height + h) / 2;
-	if(dda->line_end.y >= h)
-		dda->line_end.y = h - 1;
 	dda->line_start.x = x;
 	dda->line_end.x = x;
+	dda->line_height = line_height;
 }
 
 /**

--- a/src/texture_impl.c
+++ b/src/texture_impl.c
@@ -48,22 +48,23 @@ unsigned int get_color_info(t_game *game, t_dda_ctx *info, int i)
 {
 	t_vec2	vec;
 	int	offs;
-	double	wallh;
 
-	wallh = (double)(info->line_end.y - info->line_start.y);
-	vec.x = fmod(hit_points(game, info), 1.0) * game->frames.Dimensions[info->side][0];
+	vec.x = fmod(hit_points(game, info), 1.0) * game->frames.walltex_[info->side].width;
 	if (vec.x < 0)
 		vec.x = 0;
-	else if (vec.x >= game->frames.Dimensions[info->side][0])
-		vec.x = game->frames.Dimensions[info->side][0] - 1;
-	vec.y = (i / wallh) * game->frames.Dimensions[info->side][1];
+	else if (vec.x >= game->frames.walltex_[info->side].width)
+		vec.x = game->frames.walltex_[info->side].width;
+
+	vec.y = (double)(i / info->line_height) * game->frames.walltex_[info->side].height;
 	if (vec.y < 0)
 		vec.y = 0;
-	else if (vec.y >= game->frames.Dimensions[info->side][1])
-		vec.y = game->frames.Dimensions[info->side][1] - 1;
-	offs = (int)vec.y * game->frames.image[info->side].line_len + (int)vec.x * (game->frames.image[info->side].bpp / 8);
-	return *(unsigned int *)(game->frames.walltex_[info->side] + offs);
+	else if (vec.y >= game->frames.walltex_[info->side].height)
+		vec.y = game->frames.walltex_[info->side].height - 1;
+
+	offs = (int)vec.y * game->frames.walltex_[info->side].line_len + (int)vec.x * (game->frames.walltex_[info->side].bpp / 8);
+	return *(unsigned int *)(game->frames.walltex_[info->side].addr + offs);
 }
+
 /**
  * draw_texture_line - Draws a vertical line with ceiling, wall, and floor colors.
  * @i: Current pixel position in the column.


### PR DESCRIPTION
This pull request refactors the way wall textures are managed and accessed in the game engine, making the codebase more consistent and maintainable. The changes unify how wall texture data is stored, update the texture loading and access logic, and clean up some unused or redundant code and structures.

**Texture management and data structure improvements:**

* Refactored the `t_frames` struct to store wall textures as `t_data` objects (which include metadata like width, height, bpp, etc.) instead of storing separate arrays for image data and dimensions. (`includes/types.h`, [includes/types.hR82-R88](diffhunk://#diff-6eae8b7191610a5359bf8d1b65fbb51107870c2216d4832ed1b64de22465056fR82-R88))
* Updated the `prepare_wall_images` function to load wall textures directly into the new `t_data`-based `walltex_` array, setting all relevant fields for each texture. (`cub.c`, [cub.cL47-L66](diffhunk://#diff-bd47f545442b723cd9eb1f5fe6979fcbed069d8471c0b5809b4060df5fc7d434L47-L66))

**Texture access and rendering logic:**

* Modified texture sampling in `get_color_info` to use the new `t_data` structure, ensuring correct calculation of texture coordinates and memory offsets for rendering. (`src/texture_impl.c`, [src/texture_impl.cL51-R67](diffhunk://#diff-8d53c50b69b0ac33d7e29af9c1e075f81166e5aa9671077854410126fa3f527cL51-R67))
* Added a `line_height` field to the `t_dda_ctx` struct to simplify wall rendering calculations and updated its assignment in the DDA algorithm. (`includes/types.h`, [[1]](diffhunk://#diff-6eae8b7191610a5359bf8d1b65fbb51107870c2216d4832ed1b64de22465056fR159); `src/dda.c`, [[2]](diffhunk://#diff-c1b66415a92042f12f45cb373a3edaab95a2c9e368aaee2bed6954bf28c067a9L152-R155)

**Code cleanup and removal of unused code:**

* Removed the unused `t_parse` struct and related code, as well as the now-obsolete `is_frame_ready` function, to reduce clutter and potential confusion. (`includes/types.h`, [[1]](diffhunk://#diff-6eae8b7191610a5359bf8d1b65fbb51107870c2216d4832ed1b64de22465056fL65-L77); `cub.c`, [[2]](diffhunk://#diff-bd47f545442b723cd9eb1f5fe6979fcbed069d8471c0b5809b4060df5fc7d434L23-L36)